### PR TITLE
fix broken context menu "open file location"

### DIFF
--- a/app/ui/widgets/widget_components.py
+++ b/app/ui/widgets/widget_components.py
@@ -330,9 +330,17 @@ class TargetMediaCardButton(CardButton):
 
     def open_target_path_by_explorer(self):
         if os.path.exists(self.media_path):
+            # Normalize path
+            normalized_path = os.path.normpath(os.path.abspath(self.media_path))
+        
             if sys.platform == 'win32':
-                # Windows
-                subprocess.run(f'explorer /select,"{self.media_path}"', shell=True)
+                # Windows - use full path to explorer.exe to avoid PATH issues
+                try:
+                    # Method 1: Using subprocess without shell (more secure and reliable)
+                    subprocess.Popen(['explorer', '/select,', normalized_path])
+                except FileNotFoundError:
+                    # Fallback: Use full path to explorer.exe
+                    subprocess.Popen([r'C:\Windows\explorer.exe', '/select,', normalized_path])
             elif sys.platform == 'darwin':
                 # macOS
                 subprocess.run(['open', '-R', self.media_path])
@@ -340,6 +348,7 @@ class TargetMediaCardButton(CardButton):
                 # Linux
                 directory = os.path.dirname(os.path.abspath(self.media_path))
                 subprocess.run(['xdg-open', directory])
+
 
     def create_context_menu(self):
         self.popMenu = QtWidgets.QMenu(self)
@@ -730,12 +739,20 @@ class InputFaceCardButton(CardButton):
             print(f"{self.media_path} does not exist.")
 
         self.deleteLater()
-
+        
     def open_target_path_by_explorer(self):
         if os.path.exists(self.media_path):
+            # Normalize path
+            normalized_path = os.path.normpath(os.path.abspath(self.media_path))
+        
             if sys.platform == 'win32':
-                # Windows
-                subprocess.run(f'explorer /select,"{self.media_path}"', shell=True)
+                # Windows - use full path to explorer.exe to avoid PATH issues
+                try:
+                    # Method 1: Using subprocess without shell (more secure and reliable)
+                    subprocess.Popen(['explorer', '/select,', normalized_path])
+                except FileNotFoundError:
+                    # Fallback: Use full path to explorer.exe
+                    subprocess.Popen([r'C:\Windows\explorer.exe', '/select,', normalized_path])
             elif sys.platform == 'darwin':
                 # macOS
                 subprocess.run(['open', '-R', self.media_path])
@@ -1605,4 +1622,5 @@ class FormGroupBox(QtWidgets.QGroupBox):
         self.main_window = main_window
         self.setSizePolicy(QtWidgets.QSizePolicy.Minimum, QtWidgets.QSizePolicy.Preferred)
         self.setFlat(True)
+
 


### PR DESCRIPTION
After an user reported the issue in discord, I noticed some weird behavior too when using a portable version and trying to use "open file location" on an source image, where it kept sending me to my user documents folder and not the actual file location. Target video location seems to be fine, but I just applied the same fix for both because it's a robust solution and now opens the file locations reliably for both.